### PR TITLE
Add queuing and forward/backward functionality

### DIFF
--- a/src/core/playback.rs
+++ b/src/core/playback.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
+use std::fs::File;
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
-use std::{collections::HashMap, fs::File};
 
 use rodio::{OutputStream, Sink};
 

--- a/src/core/request.rs
+++ b/src/core/request.rs
@@ -123,6 +123,31 @@ pub async fn request_thumbnail_from_playlist(
     handles
 }
 
+pub async fn request_thumbnail_by_video_id(video_id: String) -> iced::advanced::image::Handle {
+    let mut dir = tokio::fs::read_dir("./data/thumbnails")
+        .await
+        .expect("Failed to read");
+
+    while let Ok(Some(entry)) = dir.next_entry().await {
+        let path = entry.path();
+        let file_name = path.file_name().unwrap().to_str().unwrap().to_string();
+
+        if file_name.contains(&video_id) {
+            let bytes = tokio::fs::read(path).await.expect("Failed to read file");
+            let handle = iced::advanced::image::Handle::from_bytes(bytes);
+
+            return handle;
+        }
+    }
+
+    let bytes = tokio::fs::read(PathBuf::from("./data/thumbnails/default.jpg"))
+        .await
+        .expect("Failed to read file");
+    let handle = iced::advanced::image::Handle::from_bytes(bytes);
+
+    handle
+}
+
 pub fn download_file<I: 'static + Hash + Copy + Send + Sync, T: ToString>(
     id: I,
     url: T,

--- a/src/ui/components/control_bar.rs
+++ b/src/ui/components/control_bar.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use super::helpers;
 use super::style;
 use crate::core::format;
-use crate::core::request::request_thumbnail_by_video_id;
+use crate::core::request;
 
 use iced::widget::{column, container, image, row, slider, text};
 use iced::{time, Alignment, Element, Length, Task};
@@ -106,7 +106,7 @@ impl State {
                             self.active_video_id = video_id.clone();
 
                             return Task::perform(
-                                request_thumbnail_by_video_id(video_id),
+                                request::request_thumbnail_by_video_id(video_id),
                                 Event::ThumbnailRetrieved,
                             );
                         }
@@ -146,7 +146,7 @@ impl State {
 
                 if handle.is_none() {
                     return Task::perform(
-                        request_thumbnail_by_video_id(video_id),
+                        request::request_thumbnail_by_video_id(video_id),
                         Event::ThumbnailRetrieved,
                     );
                 } else {

--- a/src/ui/components/control_bar.rs
+++ b/src/ui/components/control_bar.rs
@@ -1,6 +1,9 @@
+use std::collections::HashMap;
+
 use super::helpers;
 use super::style;
 use crate::core::format;
+use crate::core::request::request_thumbnail_by_video_id;
 
 use iced::widget::{column, container, image, row, slider, text};
 use iced::{time, Alignment, Element, Length, Task};
@@ -18,6 +21,8 @@ pub struct State {
     is_paused: bool,
     volume: f32,
     active_thumbnail_handle: Option<iced::advanced::image::Handle>,
+    tracks: Vec<HashMap<String, String>>,
+    active_video_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -28,9 +33,17 @@ pub enum Event {
     Tick,
     Mute,
     Unmute,
+    SeekTo(f32),
     ProgressChanged(f32),
     VolumeChanged(f32),
-    InitiatePlay(String, u64, Option<iced::advanced::image::Handle>),
+    InitiatePlay(
+        String,
+        String,
+        u64,
+        Option<iced::advanced::image::Handle>,
+        Vec<HashMap<String, String>>,
+    ),
+    ThumbnailRetrieved(iced::advanced::image::Handle),
 }
 
 impl State {
@@ -66,9 +79,40 @@ impl State {
                     self.slider_is_active = false;
                     self.slider_value = 0.0;
                     self.total_duration = 0;
+                    self.seconds_passed = 0;
 
                     self.formatted_current_duration = "0:00".to_string();
                     self.formatted_total_duration = "0:00".to_string();
+                    self.now_playing = "Nothing is playing.".to_string();
+
+                    let index = self
+                        .tracks
+                        .iter()
+                        .position(|x| x.get("video_id").unwrap() == &self.active_video_id);
+
+                    if index.is_some() {
+                        let next_index = index.unwrap() + 1;
+
+                        if next_index < self.tracks.len() {
+                            let next_track = self.tracks.get(next_index).unwrap();
+                            let video_id = next_track.get("video_id").unwrap().to_string();
+                            let display_name = next_track.get("display_name").unwrap().to_string();
+                            let total_duration =
+                                next_track.get("duration").unwrap().parse::<u64>().unwrap();
+
+                            self.now_playing = display_name.clone();
+                            self.slider_is_active = true;
+                            self.total_duration = total_duration;
+                            self.active_video_id = video_id.clone();
+
+                            return Task::perform(
+                                request_thumbnail_by_video_id(video_id),
+                                Event::ThumbnailRetrieved,
+                            );
+                        }
+                    }
+
+                    return Task::none();
                 }
 
                 self.formatted_current_duration = format::format_duration(self.seconds_passed);
@@ -76,14 +120,8 @@ impl State {
 
                 Task::none()
             }
-            Event::BackwardPressed => {
-                println!("Backward pressed");
-                Task::none()
-            }
-            Event::ForwardPressed => {
-                println!("Forward pressed");
-                Task::none()
-            }
+            Event::BackwardPressed => Task::none(),
+            Event::ForwardPressed => Task::none(),
 
             Event::ProgressChanged(value) => {
                 self.slider_value = value;
@@ -94,16 +132,32 @@ impl State {
 
                 Task::none()
             }
-            Event::InitiatePlay(text, total_duration, handle) => {
+            Event::InitiatePlay(video_id, display_name, total_duration, handle, tracks) => {
                 self.is_paused = false;
-                self.slider_is_active = false; // ensure slider state is reset
+                self.slider_is_active = false;
                 self.slider_value = 0.0;
                 self.seconds_passed = 0;
 
-                self.now_playing = text;
-                self.active_thumbnail_handle = handle;
+                self.now_playing = display_name.clone();
                 self.slider_is_active = true;
                 self.total_duration = total_duration;
+                self.tracks = tracks;
+                self.active_video_id = video_id.clone();
+
+                if handle.is_none() {
+                    return Task::perform(
+                        request_thumbnail_by_video_id(video_id),
+                        Event::ThumbnailRetrieved,
+                    );
+                } else {
+                    self.active_thumbnail_handle = handle;
+                }
+
+                Task::none()
+            }
+
+            Event::ThumbnailRetrieved(handle) => {
+                self.active_thumbnail_handle = Some(handle);
 
                 Task::none()
             }
@@ -114,6 +168,13 @@ impl State {
                 } else {
                     self.is_paused = true;
                 }
+
+                Task::none()
+            }
+
+            Event::SeekTo(value) => {
+                self.seconds_passed = value as u64;
+                self.slider_value = value;
 
                 Task::none()
             }
@@ -229,6 +290,8 @@ impl Default for State {
             now_playing: String::from("Nothing is playing."),
             is_paused: false,
             volume: 0.5,
+            tracks: Vec::new(),
+            active_video_id: String::new(),
         }
     }
 }

--- a/src/ui/components/nav.rs
+++ b/src/ui/components/nav.rs
@@ -1,9 +1,10 @@
+use super::helpers;
+use super::style;
+
 use iced::{
     widget::{container, horizontal_space, row, Space},
     Task,
 };
-
-use super::{helpers, style};
 
 pub struct State {}
 

--- a/src/ui/components/sidebar.rs
+++ b/src/ui/components/sidebar.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
-use crate::core::db;
-
 use super::helpers;
 use super::style;
+use crate::core::db;
 
 use iced::widget::{button, column, container, scrollable, text, Space};
 use iced::{Alignment, Length, Task};

--- a/src/ui/ffmpeg.rs
+++ b/src/ui/ffmpeg.rs
@@ -1,11 +1,11 @@
 use std::path::PathBuf;
 
-use iced::widget::{button, column, container, progress_bar, row, text};
-use iced::{Alignment, Length, Subscription, Task};
-
 use crate::core::file;
 use crate::core::json;
 use crate::core::request;
+
+use iced::widget::{button, column, container, progress_bar, row, text};
+use iced::{Alignment, Length, Subscription, Task};
 
 pub struct State {
     id: usize,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::sync::mpsc;
 
 use crate::core::json;
+use crate::core::playback;
 use crate::core::youtube;
 use components::control_bar;
 use components::sidebar;
@@ -16,9 +17,6 @@ use iced::keyboard::key;
 use iced::widget;
 use iced::widget::{column, row};
 use iced::{Subscription, Task, Theme};
-
-use self::components::theme::get_theme_from_settings;
-use crate::core::playback::{start_receiver, AudioEvent};
 
 mod components;
 mod download;
@@ -42,7 +40,7 @@ pub struct Pages {
     ffmpeg: ffmpeg::State,
     playlist: playlist::State,
 
-    playback_sender: mpsc::Sender<AudioEvent>,
+    playback_sender: mpsc::Sender<playback::AudioEvent>,
 
     toasts: Vec<toast::Toast>,
     theme: Theme,
@@ -85,10 +83,10 @@ impl Pages {
     pub fn new() -> Self {
         let (sender, reciever) = mpsc::channel();
 
-        start_receiver(reciever);
+        playback::start_receiver(reciever);
 
         let theme_value = json::get_theme().expect("Dark");
-        let matched = get_theme_from_settings(theme_value);
+        let matched = theme::get_theme_from_settings(theme_value);
 
         let current_page: Page;
 
@@ -152,7 +150,7 @@ impl Pages {
                     ..
                 }) => {
                     self.playback_sender
-                        .send(AudioEvent::PauseToggle)
+                        .send(playback::AudioEvent::PauseToggle)
                         .expect("Failed to send pause command");
 
                     self.controls
@@ -198,7 +196,7 @@ impl Pages {
                         tracks,
                     ) => {
                         self.playback_sender
-                            .send(AudioEvent::Queue(
+                            .send(playback::AudioEvent::Queue(
                                 video_id.clone().to_string(),
                                 tracks.clone(),
                             ))
@@ -374,7 +372,7 @@ impl Pages {
                         tracks,
                     ) => {
                         self.playback_sender
-                            .send(AudioEvent::Queue(
+                            .send(playback::AudioEvent::Queue(
                                 video_id.clone().to_string(),
                                 tracks.clone(),
                             ))
@@ -452,42 +450,42 @@ impl Pages {
                 match event {
                     components::control_bar::Event::ProgressChanged(value) => {
                         self.playback_sender
-                            .send(AudioEvent::SeekTo(value as u64))
+                            .send(playback::AudioEvent::SeekTo(value as u64))
                             .expect("Failed to send seek command");
 
                         controls_command
                     }
                     components::control_bar::Event::PauseToggleAction => {
                         self.playback_sender
-                            .send(AudioEvent::PauseToggle)
+                            .send(playback::AudioEvent::PauseToggle)
                             .expect("Failed to send pause command");
 
                         controls_command
                     }
                     components::control_bar::Event::VolumeChanged(value) => {
                         self.playback_sender
-                            .send(AudioEvent::SetVolume(value))
+                            .send(playback::AudioEvent::SetVolume(value))
                             .expect("Failed to send volume command");
 
                         controls_command
                     }
                     components::control_bar::Event::Mute => {
                         self.playback_sender
-                            .send(AudioEvent::Mute)
+                            .send(playback::AudioEvent::Mute)
                             .expect("Failed to send mute command");
 
                         controls_command
                     }
                     components::control_bar::Event::Unmute => {
                         self.playback_sender
-                            .send(AudioEvent::Unmute)
+                            .send(playback::AudioEvent::Unmute)
                             .expect("Failed to send unmute command");
 
                         controls_command
                     }
                     components::control_bar::Event::BackwardPressed => {
                         self.playback_sender
-                            .send(AudioEvent::Backward)
+                            .send(playback::AudioEvent::Backward)
                             .expect("Failed to send backward command");
 
                         if self.active_track_list.is_empty() {
@@ -500,7 +498,7 @@ impl Pages {
                     }
                     components::control_bar::Event::ForwardPressed => {
                         self.playback_sender
-                            .send(AudioEvent::Forward)
+                            .send(playback::AudioEvent::Forward)
                             .expect("Failed to send forward command");
 
                         if self.active_track_list.is_empty() {

--- a/src/ui/playlist.rs
+++ b/src/ui/playlist.rs
@@ -26,7 +26,13 @@ pub enum Event {
     OpenInListMode,
     OpenInCreateMode,
     CreatePlaylist,
-    PlayTrack(String, String, u64, Option<iced::advanced::image::Handle>),
+    PlayTrack(
+        String,
+        String,
+        u64,
+        Option<iced::advanced::image::Handle>,
+        Option<Vec<HashMap<String, String>>>,
+    ),
     ThumbnailHandlesReceived(Vec<HashMap<String, iced::advanced::image::Handle>>),
     OpenPlaylist(i32),
     PlaylistNameInput(String),
@@ -35,7 +41,7 @@ pub enum Event {
 impl State {
     pub fn update(&mut self, message: Event) -> Task<Event> {
         match message {
-            Event::PlayTrack(_video_id, _display_name, _duration, _handle) => Task::none(),
+            Event::PlayTrack(_video_id, _display_name, _duration, _handle, _tracks) => Task::none(),
             Event::OpenPlaylist(index) => {
                 self.playlist_view = true;
                 self.thumbnails = Vec::new();
@@ -131,7 +137,8 @@ impl State {
                                         .unwrap()
                                         .try_into()
                                         .unwrap(),
-                                    Some(handle.clone())
+                                    Some(handle.clone()),
+                                    Some(self.tracks.clone()),
                                 ))
                             ),
                             helpers::thumbnail(handle.clone()),
@@ -168,7 +175,8 @@ impl State {
                                         .unwrap()
                                         .try_into()
                                         .unwrap(),
-                                    None
+                                    None,
+                                    Some(self.tracks.clone())
                                 ))
                             ),
                             text(track.get("display_name").unwrap()),

--- a/src/ui/playlist.rs
+++ b/src/ui/playlist.rs
@@ -1,15 +1,15 @@
 use std::collections::HashMap;
 
-use super::components::{helpers, style};
+use super::components::helpers;
+use super::components::style;
+use crate::core::db;
 use crate::core::format;
+use crate::core::request;
 
 use iced::widget::{
     button, column, container, horizontal_space, row, scrollable, text, text_input,
 };
 use iced::{Alignment, Length, Task};
-
-use crate::core::db;
-use crate::core::request;
 
 pub struct State {
     create_playlist_mode: bool,

--- a/src/ui/track_list.rs
+++ b/src/ui/track_list.rs
@@ -41,7 +41,13 @@ pub enum Event {
     NewDisplayName(String),
     ShowEditModal(String, String),
     ShowAddModal(String),
-    PlayTrack(String, String, u64, Option<iced::advanced::image::Handle>),
+    PlayTrack(
+        String,
+        String,
+        u64,
+        Option<iced::advanced::image::Handle>,
+        Option<Vec<HashMap<String, String>>>,
+    ),
     KeyboardEvent(IcedEvent),
 }
 
@@ -105,7 +111,7 @@ impl State {
                 Task::none()
             }
 
-            Event::PlayTrack(_video_id, _display_name, _duration, _handle) => Task::none(),
+            Event::PlayTrack(_video_id, _display_name, _duration, _handle, _tracks) => Task::none(),
 
             Event::ShowEditModal(video_id, display_name) => {
                 info!("Showing modal for track with video_id: {}", video_id);
@@ -207,6 +213,7 @@ impl State {
                             display_name.clone(),
                             duration.parse::<u64>().unwrap(),
                             Some(thumbnail_handle.clone()),
+                            Some(self.track_list.clone())
                         )),
                     ),
                     helpers::thumbnail(thumbnail_handle.clone()),
@@ -240,6 +247,7 @@ impl State {
                             display_name.clone(),
                             duration.parse::<u64>().unwrap(),
                             None,
+                            Some(self.track_list.clone()),
                         )),
                     ),
                     text("..."),


### PR DESCRIPTION
This PR adds proper queuing functionality to automatically play the next song once the current one has ended. This can also be controlled using the forward & backward buttons on the control bar.

The backward button will restart the actively playing song to the beginning if pressed once.